### PR TITLE
Throttling Settings

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -117,3 +117,14 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+REST_FRAMEWORK ={
+    'DEFAULT_THROTTLE_CLASSES' : [
+        'rest_framework.throttling.AnonRateThrottle',
+        'rest_framework.throttling.UserRateThrottle',
+    ],
+    'DEFAULT_THROTTLE_RATES' : {
+        'anon' : '10/minute',
+        'user' : '1000/hour',
+    }
+}


### PR DESCRIPTION
This example would be configured to allow up to 10 requests per minute for an unauthenticated user and up to 1000 requests per hour for an authenticated user.